### PR TITLE
chore: update root module dependencies and bump version to v0.11.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,9 @@
 module github.com/kshard/chatter
 
-go 1.23.0
+go 1.25.0
 
 require (
 	github.com/fogfish/faults v0.3.2
 	github.com/fogfish/it/v2 v2.2.4
-	golang.org/x/time v0.11.0
+	golang.org/x/time v0.15.0
 )

--- a/go.sum
+++ b/go.sum
@@ -2,5 +2,5 @@ github.com/fogfish/faults v0.3.2 h1:kQai2/VyXJxfd6SD/jYLHiqu0qDl/KXT48q1ppLMAnY=
 github.com/fogfish/faults v0.3.2/go.mod h1:y8zvZN2pQUe9vDS7rzz0mAnbdfYMorPOeqxpy83YOCk=
 github.com/fogfish/it/v2 v2.2.4 h1:hkBePGW7X/wDc1QCLG/j+/j47TG4obnozYsGMX51yMQ=
 github.com/fogfish/it/v2 v2.2.4/go.mod h1:HHwufnTaZTvlRVnSesPl49HzzlMrQtweKbf+8Co/ll4=
-golang.org/x/time v0.11.0 h1:/bpjEDfN9tkoN/ryeYHnv5hcMlc8ncjMcM4XBk5NWV0=
-golang.org/x/time v0.11.0/go.mod h1:CDIdPxbZBQxdj6cxyCIdrNogrJKMJ7pr37NYpMcMDSg=
+golang.org/x/time v0.15.0 h1:bbrp8t3bGUeFOx08pvsMYRTCVSMk89u4tKbNOZbp88U=
+golang.org/x/time v0.15.0/go.mod h1:Y4YMaQmXwGQZoFaVFk4YpCt4FLQMYKZe9oeV/f4MSno=

--- a/version.go
+++ b/version.go
@@ -8,4 +8,4 @@
 
 package chatter
 
-const Version = "v0.11.1"
+const Version = "v0.11.2"


### PR DESCRIPTION
- Upgraded Go: 1.23.0 -> 1.25.0
- Upgraded golang.org/x/time: v0.11.0 -> v0.15.0
- Bumped version: v0.11.1 -> v0.11.2